### PR TITLE
Generalize server args

### DIFF
--- a/spyre/server.py
+++ b/spyre/server.py
@@ -18,29 +18,27 @@ ROOT_DIR = os.path.dirname(os.path.realpath(__file__))
 templateLoader = jinja2.FileSystemLoader( searchpath=ROOT_DIR )
 templateEnv = jinja2.Environment( loader=templateLoader )
 
-
-
 class Root(object):
 	def __init__(
-					self,
-					templateVars=None,
-					title=None,
-					inputs=None,
-					outputs=None,
-					controls=None,
-					tabs=None,
-					getJsonDataFunction=None,
-					getDataFunction=None,
-					getTableFunction=None,
-					getPlotFunction=None,
-					getImageFunction=None,
-					getD3Function=None,
-					getCustomCSSFunction=None,
-					getCustomJSFunction=None,
-					getHTMLFunction=None,
-					getDownloadFunction=None,
-					noOutputFunction=None,
-				):
+			self,
+			templateVars=None,
+			title=None,
+			inputs=None,
+			outputs=None,
+			controls=None,
+			tabs=None,
+			getJsonDataFunction=None,
+			getDataFunction=None,
+			getTableFunction=None,
+			getPlotFunction=None,
+			getImageFunction=None,
+			getD3Function=None,
+			getCustomCSSFunction=None,
+			getCustomJSFunction=None,
+			getHTMLFunction=None,
+			getDownloadFunction=None,
+			noOutputFunction=None,
+			):
 		# populate template dictionary for creating input,controler, and output HTML and javascript
 		if templateVars is not None:
 			self.templateVars = templateVars
@@ -48,12 +46,12 @@ class Root(object):
 			self.templateVars = {}
 			# Include any class arguments that should be added to the templateVars dictionary
 			templateVarsArgs = (
-							'title',
-							'inputs',
-							'controls',
-							'outputs',
-							'tabs'
-								)
+					'title',
+					'inputs',
+					'controls',
+					'outputs',
+					'tabs'
+					)
 			for arg in templateVarsArgs:
 				if locals()[arg] is not None:
 					self.templateVars[arg] = locals()[arg]
@@ -309,24 +307,24 @@ class App:
 
 	def getRoot(self):
 		webapp = Root(
-						templateVars=self.templateVars,
-						title=self.title,
-						inputs=self.inputs,
-						outputs=self.outputs,
-						controls=self.controls,
-						tabs=self.tabs,
-						getJsonDataFunction=self.getJsonData,
-						getDataFunction=self.getData,
-						getTableFunction=self.getTable,
-						getPlotFunction=self.getPlot,
-						getImageFunction=self.getImage,
-						getD3Function=self.getD3,
-						getCustomJSFunction=self.getCustomJS,
-						getCustomCSSFunction=self.getCustomCSS,
-						getHTMLFunction=self.getHTML,
-						getDownloadFunction=self.getDownload,
-						noOutputFunction=self.noOutput,
-					 )
+				templateVars=self.templateVars,
+				title=self.title,
+				inputs=self.inputs,
+				outputs=self.outputs,
+				controls=self.controls,
+				tabs=self.tabs,
+				getJsonDataFunction=self.getJsonData,
+				getDataFunction=self.getData,
+				getTableFunction=self.getTable,
+				getPlotFunction=self.getPlot,
+				getImageFunction=self.getImage,
+				getD3Function=self.getD3,
+				getCustomJSFunction=self.getCustomJS,
+				getCustomCSSFunction=self.getCustomCSS,
+				getHTMLFunction=self.getHTML,
+				getDownloadFunction=self.getDownload,
+				noOutputFunction=self.noOutput,
+				)
 		return webapp
 
 class Launch(App):

--- a/spyre/server.py
+++ b/spyre/server.py
@@ -7,7 +7,7 @@ import pandas as pd
 import numpy as np
 
 import model
-import View
+import view
 
 import cherrypy
 from cherrypy.lib.static import serve_file
@@ -58,13 +58,13 @@ class Root(object):
 		self.templateVars['custom_js'] = custom_js
 		self.templateVars['custom_css'] = custom_css
 
-		v = View.View()
+		v = view.View()
 		self.templateVars['js'] = v.getJS()
 		self.templateVars['css'] = v.getCSS()
 
 	@cherrypy.expose
 	def index(self):
-		v = View.View()
+		v = view.View()
 		template = jinja2.Template(v.getHTML())
 		return template.render( self.templateVars )
 
@@ -133,7 +133,7 @@ class Root(object):
 
 	@cherrypy.expose
 	def spinning_wheel(self, **args):
-		v = View.View()
+		v = view.View()
 		buffer = v.getSpinningWheel()
 		cherrypy.response.headers['Content-Type'] = 'image/gif'
 		return buffer.getvalue()

--- a/spyre/server.py
+++ b/spyre/server.py
@@ -21,34 +21,49 @@ templateEnv = jinja2.Environment( loader=templateLoader )
 
 
 class Root(object):
-	def __init__(self,templateVars=None, title=None, inputs=None, outputs=None, controls=None, tabs=None, getJsonDataFunction=None, getDataFunction=None, getTableFunction=None, getPlotFunction=None, getImageFunction=None, getD3Function=None, getCustomCSSFunction=None, getCustomJSFunction=None, getHTMLFunction=None,  getDownloadFunction=None, noOutputFunction=None):
+	def __init__(
+					self,
+					templateVars=None,
+					title=None,
+					inputs=None,
+					outputs=None,
+					controls=None,
+					tabs=None,
+					getJsonDataFunction=None,
+					getDataFunction=None,
+					getTableFunction=None,
+					getPlotFunction=None,
+					getImageFunction=None,
+					getD3Function=None,
+					getCustomCSSFunction=None,
+					getCustomJSFunction=None,
+					getHTMLFunction=None,
+					getDownloadFunction=None,
+					noOutputFunction=None,
+				):
 		# populate template dictionary for creating input,controler, and output HTML and javascript
 		if templateVars is not None:
 			self.templateVars = templateVars
 		else:
 			self.templateVars = {}
-			if title is not None:
-				self.templateVars['title'] = title
-			if inputs is not None:
-				self.templateVars['inputs'] = inputs
-			if controls is not None:
-				self.templateVars['controls'] = controls
-			if outputs is not None:
-				self.templateVars['outputs'] = outputs
-			if tabs is not None:
-				self.templateVars['tabs'] = tabs
+			# Include any class arguments that should be added to the templateVars dictionary
+			templateVarsArgs = (
+							'title',
+							'inputs',
+							'controls',
+							'outputs',
+							'tabs'
+								)
+			for arg in templateVarsArgs:
+				if locals()[arg] is not None:
+					self.templateVars[arg] = locals()[arg]
 
-		self.getJsonData = getJsonDataFunction
-		self.getData = getDataFunction
-		self.getTable = getTableFunction
-		self.getPlot = getPlotFunction
-		self.getImage = getImageFunction
-		self.getD3 = getD3Function
-		self.getCustomJS = getCustomJSFunction
-		self.getCustomCSS = getCustomCSSFunction
-		self.getHTML = getHTMLFunction
-		self.noOutput = noOutputFunction
-		self.getDownload = getDownloadFunction
+		# Adds any class arguments that have 'Function' to the object, with an attribute name omitting 'Function'
+		for key in locals().keys():
+			if 'Function' in key:
+				objAttributeName = key.replace('Function','')
+				setattr(self,objAttributeName,locals()[key])
+
 		d3 = self.getD3()
 		custom_js = self.getCustomJS()
 		custom_css = self.getCustomCSS()
@@ -293,7 +308,25 @@ class App:
 		return HTML('<iframe src=http://localhost:{} width={} height={}></iframe>'.format(port,width,height))
 
 	def getRoot(self):
-		webapp = Root(templateVars=self.templateVars, title=self.title, inputs=self.inputs, outputs=self.outputs, controls=self.controls, tabs=self.tabs, getJsonDataFunction=self.getJsonData, getDataFunction=self.getData, getTableFunction=self.getTable, getPlotFunction=self.getPlot, getImageFunction=self.getImage, getD3Function=self.getD3, getCustomJSFunction=self.getCustomJS, getCustomCSSFunction=self.getCustomCSS, getHTMLFunction=self.getHTML, getDownloadFunction=self.getDownload, noOutputFunction=self.noOutput)
+		webapp = Root(
+						templateVars=self.templateVars,
+						title=self.title,
+						inputs=self.inputs,
+						outputs=self.outputs,
+						controls=self.controls,
+						tabs=self.tabs,
+						getJsonDataFunction=self.getJsonData,
+						getDataFunction=self.getData,
+						getTableFunction=self.getTable,
+						getPlotFunction=self.getPlot,
+						getImageFunction=self.getImage,
+						getD3Function=self.getD3,
+						getCustomJSFunction=self.getCustomJS,
+						getCustomCSSFunction=self.getCustomCSS,
+						getHTMLFunction=self.getHTML,
+						getDownloadFunction=self.getDownload,
+						noOutputFunction=self.noOutput,
+					 )
 		return webapp
 
 class Launch(App):


### PR DESCRIPTION
I am not sure if you intentionally left the references to view.py as is, but it's definitely causing issues, as written. Thus the first commit in this pull request is to update those references from View to view.

I changed the formatting to the `Root.__init__` function and the Root instantiation in the `App.getRoot` method, so that it would be easier to see all the arguments. This is more of a stylistic changed, but I think it would be helpful to be able to see all the arguments. When I was playing around with adding the multiple app/site functionality, I had to add another argument, and by putting each argument on a single line, the diff is much more clear. Without this, the diff just shows a multi-line block being replaced by another multi-line block. Now if any arguments are added or removed they will show up as single line diffs.

I also created a more convenient way of populating the `templateVars` dictionary, so that the addition of another key value pair only requires an addition to the Root arguments and an addition to the `templateVarsArgs` tuple. There is then a loop through `templateVarsArgs` that checks if it was set in the `Root` arguments, and if it was, it adds it to the `templateVars` dictionary.

I also did this with the functions. The expectation is that additional functions will have the following convention:

    Root.someMethod is defined by an argument of Root.__init__ with the form someMethodFunction

So to add an additional function method to the `Root` object, you just need to add the keyword argument definition in the `Root.__init__` arguments list with the naming convention of including "Function" on the end of the key. This will then cause it to be picked up and added to the `Root` object as a method.

I think these changes will help to make adding methods and template variables more easy, and more clear.

What do you think?