### PR TITLE
cleaner sub-outputs

### DIFF
--- a/spyre/example_show_all_the_inputs.py
+++ b/spyre/example_show_all_the_inputs.py
@@ -73,6 +73,11 @@ class SimpleSineApp(server.App):
 					"control_id" : "button1",
 					"on_page_load" : True,
 				},
+				{	"output_type" : "plot",
+					"output_id" : "plot2",
+					"control_id" : "button1",
+					"on_page_load" : True,
+				},
 				{	"output_type" : "table",
 					"output_id" : "table_id",
 					"control_id" : "button1",
@@ -85,30 +90,67 @@ class SimpleSineApp(server.App):
 				}]
 
 	def getPlot(self, params):
+		fig = plt.figure()  # make figure object
+		splt = fig.add_subplot(1,1,1)
+
 		f = float(params['freq'])
-		time.sleep(f/2)
 		title = params['title']
 		axis_label = map( int, params['axis_label'] )
 		color = params['color']
 		func_type = params['func_type']
 
 		x = np.arange(0,6*pi,pi/50)
-		plt.title(title)
+		splt.set_title(title)
 		for axis in axis_label:
 			if axis==1:
-				plt.xlabel('x axis')
+				splt.set_xlabel('x axis')
 			if axis==2:
-				plt.ylabel('y axis')
+				splt.set_ylabel('y axis')
 		if func_type=='cos':
 			y = np.cos(f*x)
 		else:
 			y = np.sin(f*x)
-		plt.plot(x,y,color=color)  # sine wave
-		return plt.gcf()
+		splt.plot(x,y,color=color)  # sine wave
+		return fig
 
-	def getHTML(self,params):
-		f = int(params['freq'])
-		time.sleep(f)
+	# def getHTML(self,params):
+	# 	f = int(params['freq'])
+	# 	time.sleep(f)
+	# 	return "hello world"
+	
+	def plot(self):
+		fig = plt.figure()  # make figure object
+		splt = fig.add_subplot(1,1,1)
+
+		f = float(params['freq'])
+		title = params['title']
+		axis_label = map( int, params['axis_label'] )
+		color = params['color']
+		func_type = params['func_type']
+
+		x = np.arange(0,6*pi,pi/50)
+		splt.set_title(title)
+		for axis in axis_label:
+			if axis==1:
+				splt.set_xlabel('x axis')
+			if axis==2:
+				splt.set_ylabel('y axis')
+		if func_type=='cos':
+			y = np.cos(f*x)
+		else:
+			y = np.sin(f*x)
+		splt.plot(x,y,color=color)  # sine wave
+		return fig
+
+	def plot2(self):
+		fig = plt.figure()  # make figure object
+		splt = fig.add_subplot(1,1,1)
+		x = np.arange(0,6*pi,pi/50)
+		y = np.sin(f*x)
+		splt.plot(x,y)  # sine wave
+		return fig
+
+	def html_id(self):
 		return "hello world"
 
 	def getData(self,params):

--- a/spyre/server.py
+++ b/spyre/server.py
@@ -190,10 +190,10 @@ class App:
 		returns:
 		DataFrame
 		"""
-		count = [1,4,3]
-		name = ['Override','getData() method','to generate tables']
-		df = pd.DataFrame({'name':name, 'count':count})
-		return df
+		try:
+			return eval("self."+str(params['output_id'])+"()")
+		except:
+			return pd.DataFrame({'name':['Override','getData() method','to generate tables'], 'count':[1,4,3]})
 
 	def getTable(self, params):
 		"""Used to create html table. Uses dataframe returned by getData by default
@@ -225,8 +225,11 @@ class App:
 		returns:
 		matplotlib.pyplot figure
 		"""
-		plt.title("Override getPlot() method to generate figures")
-		return plt.gcf()
+		try:
+			return eval("self."+str(params['output_id'])+"()")
+		except:
+			plt.title("Override getPlot() method to generate figures")
+			return plt.gcf()
 
 	def getImage(self, params):
 		"""Override this function
@@ -234,7 +237,10 @@ class App:
 		arguments: params (dict)
 		returns: matplotlib.image (figure)
 		"""
-		return np.array([[0,0,0]])
+		try:
+			return eval("self."+str(params['output_id'])+"()")
+		except:
+			return np.array([[0,0,0]])
 
 	def getHTML(self, params):
 		"""Override this function
@@ -242,7 +248,10 @@ class App:
 		arguments: params (dict)
 		returns: html (string)
 		"""
-		return "<b>Override</b> the getHTML method to insert your own HTML <i>here</i>"
+		try:
+			return eval("self."+str(params['output_id'])+"()")
+		except:
+			return "<b>Override</b> the getHTML method to insert your own HTML <i>here</i>"
 
 	def noOutput(self, params):
 		"""Override this function
@@ -252,7 +261,10 @@ class App:
 		arguments:
 		params (dict)
 		"""
-		pass
+		try:
+			return eval("self."+str(params['output_id'])+"()")
+		except:
+			pass
 
 	def getD3(self):
 		d3 = {}


### PR DESCRIPTION
@huntcsg these changes allow you to define sub-output methods by writing a method for each sub-output with a name that matches the output_id.

For instance if this were the dictionary defining the outputs:

````
outputs = [{"output_type" : "plot",
			"output_id" : "plot1" },
			{"output_type" : "plot",
			"output_id" : "plot2" }]
````

The methods to generate those two plot outputs would be:

````
def plot1(self, params):
	fig1 = plt.figure()
	# code to generate a plot
	return fig1

def plot1(self, params):
	fig2 = plt.figure()
	# code to generate a different plot
	return fig2
````

When using this method to generate plots (or other outputs) the getPlot method *should not* be overridden.