### PR TITLE
Fix handling of option values containing whitespace.

### DIFF
--- a/spyre/view.html
+++ b/spyre/view.html
@@ -30,8 +30,8 @@
 					{% elif input['input_type']=="slider" -%}
 						var {{input['variable_name']}} = "__float__".concat($("#{{input['variable_name']}}").val());
 					{% else %}
-						var selected_val = {{input}}.options[$("#ticker").prop("selectedIndex")]['value'];
-						var {{input['variable_name']}} = selected_val
+						var selected_val = {{input}}.options[$("#".concat({{input}}.variable_name)).prop("selectedIndex")]['value'];
+						var {{input['variable_name']}} = selected_val;
 					{%- endif %}
 					shared_params = shared_params+"{{input['variable_name']}}="+{{input['variable_name']}}+"&";
 				{%- endfor %}

--- a/spyre/view.html
+++ b/spyre/view.html
@@ -30,7 +30,8 @@
 					{% elif input['input_type']=="slider" -%}
 						var {{input['variable_name']}} = "__float__".concat($("#{{input['variable_name']}}").val());
 					{% else %}
-						var {{input['variable_name']}} = $("#{{input['variable_name']}}").val();
+						var selected_val = {{input}}.options[$("#ticker").prop("selectedIndex")]['value'];
+						var {{input['variable_name']}} = selected_val
 					{%- endif %}
 					shared_params = shared_params+"{{input['variable_name']}}="+{{input['variable_name']}}+"&";
 				{%- endfor %}


### PR DESCRIPTION
On OSX (10.10.1 and 10.10.2) I have encountered a problem when using option values with whitespaces. For example, consider `StockExample`, if I modify the inputs as follows:
```
    inputs = [{     "input_type":'dropdown',
                    "label": 'Company', 
                    "options" : [ {"label": "Google", "value":"GOOG"},
                                  {"label": "Yahoo", "value":"YHOO"},
                                  {"label": "Hello World", "value":"HELLO WORLD"},
                                  {"label": "Apple", "value":"AAPL"}],
                    "variable_name": 'ticker', 
                    "action_id": "update_data" }]
```
Selecting the "Hello World" option on the dashboard passes a truncated parameter back to `getPlot`, i.e. `params['ticker']` ==> `HELLO`. It turns out the whitespace handling was broken in the jQuery side of things. 

With this patch, given the above example we can get `params['ticker']` ==> `HELLO WORLD` as expected.

This fix is not yet applied to radiobuttons, checkgroups, or slider controls.