### PR TITLE
Fix python3.4 decoding error

### DIFF
--- a/spyre/View.py
+++ b/spyre/View.py
@@ -30,7 +30,7 @@ class View:
 		for file in os.listdir(self.JS_PATH):
 			if file.find('.js')>0:
 				file_path = os.path.join(self.JS_PATH, file) 
-				f = codecs.open(file_path)
+				f = codecs.open(file_path, 'rb')
 				content = f.read()
 				f.close()
 				self.JS += content.decode('utf-8')


### PR DESCRIPTION
Addresses this error I got while running `simple_sine_example.py`:

```python
$ python simple_sine_example.py
Warning: unable to set defaultencoding to utf-8
Traceback (most recent call last):
  File "simple_sine_example.py", line 28, in <module>
    app.launch()
  File "/Users/silvester/workspace/spyre/spyre/server.py", line 315, in launch
    webapp = self.getRoot()
  File "/Users/silvester/workspace/spyre/spyre/server.py", line 333, in getRoot
    webapp = Root(templateVars=self.templateVars, title=self.title, inputs=self.inputs, outputs=self.outputs, controls=self.controls, tabs=self.tabs, getJsonDataFunction=self.getJsonData, getDataFunction=self.getData, getTableFunction=self.getTable, getPlotFunction=self.getPlot, getImageFunction=self.getImage, getD3Function=self.getD3, getCustomJSFunction=self.getCustomJS, getCustomCSSFunction=self.getCustomCSS, getHTMLFunction=self.getHTML, getDownloadFunction=self.getDownload, noOutputFunction=self.noOutput)
  File "/Users/silvester/workspace/spyre/spyre/server.py", line 79, in __init__
    self.templateVars['js'] = v.getJS()
  File "/Users/silvester/workspace/spyre/spyre/View.py", line 36, in getJS
    self.JS += content.decode('utf-8')
AttributeError: 'str' object has no attribute 'decode'
```