### PR TITLE
Urlencode

### DIFF
--- a/spyre/view.html
+++ b/spyre/view.html
@@ -40,8 +40,8 @@
 				    history.pushState('','','?'+shared_params);
 				}
 				shared_params_old = shared_params;
-				return shared_params;
-			}
+				return encodeURI(shared_params);
+		}
 			// when an input value changes, executes the action id and/or updates any linked variables
 			// key/action_id is the name/action_id of variable being actively changed
 			// referenced_by is either 'id' (for text, dropdown, or slider) or 'name' (for checkboxgroup or radiobuttons)

--- a/spyre/view.html
+++ b/spyre/view.html
@@ -41,7 +41,7 @@
 				}
 				shared_params_old = shared_params;
 				return encodeURI(shared_params);
-		}
+			}
 			// when an input value changes, executes the action id and/or updates any linked variables
 			// key/action_id is the name/action_id of variable being actively changed
 			// referenced_by is either 'id' (for text, dropdown, or slider) or 'name' (for checkboxgroup or radiobuttons)


### PR DESCRIPTION
This change would encode all the shared parameters before they hit the server (at which point they are encoded).

This came up because I have some text box parameters that contain '%'. This change will change the incoming parameters to when they hit the server.

Below is the example I ran into. There is a '%' in the 'text' variable.  The expected output/ascii representation of the field 'text' is PUNTAV5.883%10/26.

Without encoding this is the URL:

 "GET /html?text=PUNTAV5.883%10/26"

that gets translated to:

{'text': PUNTAV5.883\x10/26'}

With encoding:

"GET /html?text=%20PUNTAV5.883%2510/26%20"

{'text': ' PUNTAV5.883%10/26 '}