### PR TITLE
Spyre CSS & HTML Refactoring

### DIFF
--- a/spyre/public/css/style.css
+++ b/spyre/public/css/style.css
@@ -1,18 +1,25 @@
-h1{
+/*
+*
+* Spyre CSS
+*
+*/
+
+
+h1 {
 	font-family: Arial, Helvetica, sans-serif;
 	font-size: 24px;
 	font-color: #333333;  
 	margin: 5px;
 }
 
-hr{
+hr {
 	background: #333333;
 	padding-top: 4px;
 	border-radius: 5px;
 	width: 95%;
 }
 
-.slider{
+.slider {
 	padding:2px;
 	margin:1px 1px 8px 1px;
 	height:30px;
@@ -96,11 +103,11 @@ img {
 	 max-width: 100%;
 }
 
-.outer{
+.outer {
 	padding: 15px;
 }
-.left-panel
-{   
+
+.left-panel {   
 	font: 14px bold;
 	font-family: Arial, Helvetica, sans-serif;
 	font-color: #333333;	 
@@ -109,8 +116,8 @@ img {
 	width:20%;
 	float:left;  
 }
-.right-panel
-{		
+
+.right-panel {		
 	background-color:white;
 	padding: 0px 5px 5px 15px;
 	width:75%;
@@ -131,8 +138,7 @@ img {
 }
 
 /*----- Table -----*/
-table.sortable
-{
+table.sortable {
 	font-family: Arial, Helvetica, sans-serif;;
 	font-size: 12px;
 	background: #fff;
@@ -141,28 +147,27 @@ table.sortable
 	border-collapse: collapse;
 	text-align: left;
 }
-table.sortable thead
-{
+
+table.sortable thead {
 	font-size: 14px;
 	font-weight: normal;
 	color: #039;
 	padding: 10px 8px;
 	border-bottom: 2px solid #6678b1;
 }
-table.sortable td
-{
+table.sortable td {
 	border-bottom: 1px solid #ccc;
 	color: #669;
 	padding: 6px 8px;
 }
-table.sortable th
-{
+
+table.sortable th {
 	border-bottom: 1px solid #ccc;
 	color: #669;
 	padding: 6px 8px;
 }
-table.sortable tbody tr:hover td
-{
+
+table.sortable tbody tr:hover td {
 	color: #009;
 }
 
@@ -173,61 +178,61 @@ table.sortable tbody tr:hover td
 	display:inline-block;
 }
  
-	/*----- Tab Links -----*/
-	/* Clearfix */
-	.apptab-links:after {
-		display:block;
-		clear:both;
-		content:'';
-	}
+/*----- Tab Links -----*/
+/* Clearfix */
+.apptab-links:after {
+	display:block;
+	clear:both;
+	content:'';
+}
 
-	ul {
-		margin:0px;
-	}
+ul {
+	margin:0px;
+}
+
+.apptab-links li {
+	margin:5px 5px;
+	float:left;
+	list-style:none;
+}
+
+.apptab-links a {
+	padding:6px 6px;
+	display:inline-block;
+	border-radius:3px 3px 3px 3px;
+	background:CornflowerBlue;
+	font-size:16px;
+	min-width: 50px;
+	text-align: center;
+	font-weight:600;
+	color:#000000;
+	text-decoration: none;
+	transition:all linear 0.15s;
+}
+
+.apptab-links a:hover {
+	background:#DDC4C4;
+	text-decoration:none;
+}
+
+li.active a, li.active a:hover {
+	background:#fdfdfd;
+	color:#000000;
+}
  
-	.apptab-links li {
-		margin:5px 5px;
-		float:left;
-		list-style:none;
-	}
+/*----- Content of Tabs -----*/
+.apptab-content {
+	padding:10px;
+	background:#fdfdfd;
+}
  
-		.apptab-links a {
-			padding:6px 6px;
-			display:inline-block;
-			border-radius:3px 3px 3px 3px;
-			background:#CCCCCC;
-			font-size:16px;
-			min-width: 50px;
-			text-align: center;
-			font-weight:600;
-			color:#000000;
-			text-decoration: none;
-			transition:all linear 0.15s;
-		}
- 
-		.apptab-links a:hover {
-			background:#DDC4C4;
-			text-decoration:none;
-		}
- 
-	li.active a, li.active a:hover {
-		background:#fdfdfd;
-		color:#000000;
-	}
- 
-	/*----- Content of Tabs -----*/
-	.apptab-content {
-		padding:10px;
-		background:#fdfdfd;
-	}
- 
-		.apptab {
-			display:none;
-		}
- 
-		.apptab.active {
-			display:block;
-		}
+.apptab {
+	display:none;
+}
+
+.apptab.active {
+	display:block;
+}
 
 
 
@@ -238,58 +243,58 @@ table.sortable tbody tr:hover td
 	display:inline-block;
 }
  
-	/*----- Tab Links -----*/
-	/* Clearfix */
-	.tab-links:after {
-		display:block;
-		clear:both;
-		content:'';
-	}
+/*----- Tab Links -----*/
+/* Clearfix */
+.tab-links:after {
+	display:block;
+	clear:both;
+	content:'';
+}
 
-	ul {
-		margin:0px;
-	}
+ul {
+	margin:0px;
+}
+
+.tab-links li {
+	margin:0px 5px;
+	float:left;
+	list-style:none;
+}
  
-	.tab-links li {
-		margin:0px 5px;
-		float:left;
-		list-style:none;
-	}
+.tab-links a {
+	padding:9px 15px;
+	display:inline-block;
+	border-radius:3px 3px 0px 0px;
+	background:#f4f4f4;
+	font-size:16px;
+	min-width: 50px;
+	text-align: center;
+	font-weight:600;
+	color:#000000;
+	text-decoration: none;
+	transition:all linear 0.15s;
+}
  
-		.tab-links a {
-			padding:9px 15px;
-			display:inline-block;
-			border-radius:3px 3px 0px 0px;
-			background:#f4f4f4;
-			font-size:16px;
-			min-width: 50px;
-			text-align: center;
-			font-weight:600;
-			color:#000000;
-			text-decoration: none;
-			transition:all linear 0.15s;
-		}
+.tab-links a:hover {
+	background:#DDC4C4;
+	text-decoration:none;
+}
  
-		.tab-links a:hover {
-			background:#DDC4C4;
-			text-decoration:none;
-		}
+li.active a, li.active a:hover {
+	background:#fdfdfd;
+	color:#000000;
+}
+
+/*----- Content of Tabs -----*/
+.tab-content {
+	padding:15px;
+	background:#fdfdfd;
+}
  
-	li.active a, li.active a:hover {
-		background:#fdfdfd;
-		color:#000000;
-	}
- 
-	/*----- Content of Tabs -----*/
-	.tab-content {
-		padding:15px;
-		background:#fdfdfd;
-	}
- 
-		.tab {
-			display:none;
-		}
- 
-		.tab.active {
-			display:block;
-		}
+.tab {
+	display:none;
+}
+
+.tab.active {
+	display:block;
+}

--- a/spyre/public/css/style.css
+++ b/spyre/public/css/style.css
@@ -202,22 +202,24 @@ img {
 * Panels
 */
 
-.menu {   
+.menu {
+	position: fixed;
+	-webkit-transform: translateZ(0);
+	transform: translateZ(0px);
 	font-size: 14px;
 	font-family: Arial, Helvetica, sans-serif;
 	color: #333333;	 
 	background: #f4f4f4;
 	padding: 10px;
-	width: 25%;
+	width: 280px;
 	box-sizing: border-box;
-	float: left;
 }
 
 .content {		
-	padding: 0px 5px 5px 15px;
-	width: 75%;
+	padding: 0;
 	box-sizing: border-box;
-	float: left;
+	margin-left: 280px;
+	max-width: 100%;
 }​
 
 /*
@@ -244,7 +246,7 @@ table.sortable {
 	font-family: Arial, Helvetica, sans-serif;;
 	font-size: 12px;
 	background: #fff;
-	min-width: 480px;
+	min-width: 420px;
 	max-width: 100%;
 	border-collapse: collapse;
 	text-align: left;
@@ -397,13 +399,15 @@ table.sortable tbody tr:hover td {
 * Responsive
 */
 
-@media (max-width: 600px) {
+@media (max-width: 760px) {
 	.menu,
 	.content {
+		position: relative;
 		width: 100%;
 	}
 
 	.content {
+		margin: 0;
 		padding-top: 30px;
 	}
 }

--- a/spyre/public/css/style.css
+++ b/spyre/public/css/style.css
@@ -171,7 +171,7 @@ li.active a, li.active a:hover {
 * <img>
 */
 
-.spyreImg {
+img {
 	max-width: 100%;
 }
 

--- a/spyre/public/css/style.css
+++ b/spyre/public/css/style.css
@@ -8,7 +8,7 @@
 h1 {
 	font-family: Arial, Helvetica, sans-serif;
 	font-size: 24px;
-	font-color: #333333;  
+	color: #333333;  
 	margin: 5px;
 }
 
@@ -110,7 +110,7 @@ img {
 .left-panel {   
 	font: 14px bold;
 	font-family: Arial, Helvetica, sans-serif;
-	font-color: #333333;	 
+	color: #333333;	 
 	background: #f4f4f4;
 	padding: 10px;
 	width:20%;

--- a/spyre/public/css/style.css
+++ b/spyre/public/css/style.css
@@ -67,7 +67,19 @@ li.active a, li.active a:hover {
 */
 
 .container {
-	padding: 20px;
+	box-sizing: border-box;
+	display: block;
+}
+
+.container:before {
+	content: "";
+	display: table;
+}
+
+.container:after {
+	content: "";
+	display: table;
+	clear: both;
 }
 
 /*

--- a/spyre/public/css/style.css
+++ b/spyre/public/css/style.css
@@ -5,6 +5,10 @@
 */
 
 
+/*
+* Base classes
+*/
+
 h1 {
 	font-family: Arial, Helvetica, sans-serif;
 	font-size: 24px;
@@ -19,27 +23,6 @@ hr {
 	width: 95%;
 }
 
-.slider {
-	padding:2px;
-	margin:1px 1px 8px 1px;
-	height:30px;
-	background: #f4f4f4
-}
-
-.slider_value {
-	padding: 3px 1px !important;
-	margin: 2px 2px !important;
-	border: 1px 2px;
-	text-align: center;
-	font-size: 12px;
-	float:left;
-	width:14%;
-}
-
-.slider_slider {
-	width:62% !important;
-}
-
 input {
 	display: block;
 	padding: 5px !important;
@@ -49,13 +32,6 @@ input {
 	width: 100%;
 	box-sizing: border-box;  /* Ensures that the input will not extend past the input panel */
 }
-
-/* 
-input:focus,
-input:hover {
-	width: 250%;
-}
-*/
 
 input[type="radio"] {
 	display: inline-block;
@@ -81,6 +57,46 @@ select {
 	height: 30px;
 }
 
+ul {
+	margin:0px;
+}
+
+li.active a, li.active a:hover {
+	background:#fdfdfd;
+	color:#000000;
+}
+
+/*
+* Slider
+*/
+
+
+.slider {
+	padding:2px;
+	margin:1px 1px 8px 1px;
+	height:30px;
+	background: #f4f4f4
+}
+
+.slider_value {
+	padding: 3px 1px !important;
+	margin: 2px 2px !important;
+	border: 1px 2px;
+	text-align: center;
+	font-size: 12px;
+	float:left;
+	width:14%;
+}
+
+.slider_slider {
+	width:62% !important;
+}
+
+
+/*
+* Button
+*/
+
 .button {
 	display: block;
 	font-size: 14px;
@@ -99,13 +115,9 @@ select {
 	cursor: pointer;
 }
 
-img {
-	 max-width: 100%;
-}
-
-.outer {
-	padding: 15px;
-}
+/*
+* Panels
+*/
 
 .left-panel {   
 	font: 14px bold;
@@ -124,7 +136,6 @@ img {
 	float:left;
 }​
 
-
 .bar {
   fill: orange;
 }
@@ -137,7 +148,10 @@ img {
   display: none;
 }
 
-/*----- Table -----*/
+/*
+* Table
+*/
+
 table.sortable {
 	font-family: Arial, Helvetica, sans-serif;;
 	font-size: 12px;
@@ -172,22 +186,19 @@ table.sortable tbody tr:hover td {
 }
 
 
-/*----- APP Tabs -----*/
+/*
+* Tabs
+*/
+
 .apptabs {
 	width:100%;
 	display:inline-block;
 }
  
-/*----- Tab Links -----*/
-/* Clearfix */
 .apptab-links:after {
 	display:block;
 	clear:both;
 	content:'';
-}
-
-ul {
-	margin:0px;
 }
 
 .apptab-links li {
@@ -213,11 +224,6 @@ ul {
 .apptab-links a:hover {
 	background:#DDC4C4;
 	text-decoration:none;
-}
-
-li.active a, li.active a:hover {
-	background:#fdfdfd;
-	color:#000000;
 }
  
 /*----- Content of Tabs -----*/

--- a/spyre/public/css/style.css
+++ b/spyre/public/css/style.css
@@ -9,6 +9,10 @@
 * Base classes
 */
 
+body {
+	margin: 10px;
+}
+
 h1 {
 	font-family: Arial, Helvetica, sans-serif;
 	font-size: 24px;
@@ -23,7 +27,7 @@ input {
 	display: block;
 	padding: 5px;
 	margin: 5px 0 0;
-	font: 14px bold;
+	font-size: 14px;
 	font-family: Arial, Helvetica, sans-serif;
 	width: 100%;
 	box-sizing: border-box;  /* Ensures that the input will not extend past the input panel */
@@ -44,12 +48,11 @@ input[type="checkbox"] {
 }
 
 select {
-	padding: 5px;
-	margin: 5px 0 11px 5px;
-	font: 14px bold;
+	font-size: 14px;
+	display: block;
 	font-family: Arial, Helvetica, sans-serif;
 	background: #f4f4f4;
-	width: 80%;
+	width: 100%;
 	height: 30px;
 }
 
@@ -200,7 +203,7 @@ li.active a, li.active a:hover {
 */
 
 .menu {   
-	font: 14px bold;
+	font-size: 14px;
 	font-family: Arial, Helvetica, sans-serif;
 	color: #333333;	 
 	background: #f4f4f4;

--- a/spyre/public/css/style.css
+++ b/spyre/public/css/style.css
@@ -329,33 +329,34 @@ table.sortable tbody tr:hover td {
 }
 
 .tab-links li {
-	margin:0px 5px;
-	float:left;
-	list-style:none;
+	margin: 0px 5px;
+	float: left;
+	list-style: none;
 }
  
 .tab-links a {
-	padding:9px 15px;
-	display:inline-block;
-	border-radius:3px 3px 0px 0px;
-	background:#f4f4f4;
-	font-size:16px;
+	padding: 9px 15px;
+	display: inline-block;
+	border-radius: 3px 3px 0px 0px;
+	background: #f4f4f4;
+	font-size: 16px;
 	min-width: 50px;
 	text-align: center;
-	font-weight:600;
-	color:#000000;
+	font-weight: 600;
+	color: #000000;
 	text-decoration: none;
-	transition:all linear 0.15s;
 }
  
 .tab-links a:hover {
-	background:#DDC4C4;
-	text-decoration:none;
+	background: #585858;
+	color: #FFF;
+	text-decoration: none;
 }
  
-li.active a, li.active a:hover {
-	background:#fdfdfd;
-	color:#000000;
+.tab-links.active a,
+.tab-links.active a:hover {
+	background: #fdfdfd;
+	color: #000000;
 }
 
 /*----- Content of Tabs -----*/

--- a/spyre/public/css/style.css
+++ b/spyre/public/css/style.css
@@ -251,10 +251,6 @@ li.active a, li.active a:hover {
 	content:'';
 }
 
-ul {
-	margin:0px;
-}
-
 .tab-links li {
 	margin:0px 5px;
 	float:left;

--- a/spyre/public/css/style.css
+++ b/spyre/public/css/style.css
@@ -25,8 +25,8 @@ hr {
 
 input {
 	display: block;
-	padding: 5px !important;
-	margin: 5px 0 0 !important;
+	padding: 5px;
+	margin: 5px 0 0;
 	font: 14px bold;
 	font-family: Arial, Helvetica, sans-serif;
 	width: 100%;
@@ -35,21 +35,21 @@ input {
 
 input[type="radio"] {
 	display: inline-block;
-	padding: 5px !important;
-	margin: 0 0 10px 5px !important;
+	padding: 5px;
+	margin: 0 0 10px 5px;
 	width: 10%;
 }
 
 input[type="checkbox"] {
 	display: inline-block;
-	padding: 5px !important;
-	margin: 0 0 10px 5px !important;
+	padding: 5px;
+	margin: 0 0 10px 5px;
 	width: 10%;
 }
 
 select {
-	padding: 5px !important;
-	margin: 5px 0 11px 5px !important;
+	padding: 5px;
+	margin: 5px 0 11px 5px;
 	font: 14px bold;
 	font-family: Arial, Helvetica, sans-serif;
 	background: #f4f4f4;
@@ -86,8 +86,8 @@ li.active a, li.active a:hover {
 }
 
 .slider_value {
-	padding: 3px 1px !important;
-	margin: 2px 2px !important;
+	padding: 3px 1px;
+	margin: 2px 2px;
 	border: 1px 2px;
 	text-align: center;
 	font-size: 12px;
@@ -96,7 +96,7 @@ li.active a, li.active a:hover {
 }
 
 .slider_slider {
-	width:62% !important;
+	width:62%;
 }
 
 

--- a/spyre/public/css/style.css
+++ b/spyre/public/css/style.css
@@ -84,6 +84,7 @@ li.active a, li.active a:hover {
 
 /*
 * Paddings
+* XS: 5px;
 * S: 10px;
 * M: 20px;
 */
@@ -112,6 +113,12 @@ li.active a, li.active a:hover {
 .spyrePad--vertS {
 	padding-top: 10px;
 	padding-bottom: 10px;
+	box-sizing: border-box;
+}
+
+.spyrePad--vertXS {
+	padding-top: 5px;
+	padding-bottom: 5px;
 	box-sizing: border-box;
 }
 

--- a/spyre/public/css/style.css
+++ b/spyre/public/css/style.css
@@ -244,7 +244,7 @@ table.sortable {
 	font-family: Arial, Helvetica, sans-serif;;
 	font-size: 12px;
 	background: #fff;
-	min-width: 380px;
+	min-width: 480px;
 	max-width: 100%;
 	border-collapse: collapse;
 	text-align: left;

--- a/spyre/public/css/style.css
+++ b/spyre/public/css/style.css
@@ -13,14 +13,10 @@ h1 {
 	font-family: Arial, Helvetica, sans-serif;
 	font-size: 24px;
 	color: #333333;  
-	margin: 5px;
-}
-
-hr {
-	background: #333333;
-	padding-top: 4px;
-	border-radius: 5px;
-	width: 95%;
+	margin: 5px 0 20px;
+	padding: 0 0 4px 0;
+	text-transform: uppercase;
+	border-bottom: 5px solid #333;
 }
 
 input {

--- a/spyre/public/css/style.css
+++ b/spyre/public/css/style.css
@@ -57,12 +57,12 @@ select {
 }
 
 ul {
-	margin:0px;
+	margin: 0px;
 }
 
 li.active a, li.active a:hover {
-	background:#fdfdfd;
-	color:#000000;
+	background: #fdfdfd;
+	color: #000000;
 }
 
 /*
@@ -188,7 +188,7 @@ li.active a, li.active a:hover {
 	text-align: center;
 	color: #ffffff;
 	background-color: #777777;
-  	width:80%;
+  	width: 80%;
   	border: 1px solid;
 	border-radius: 8px;
 }
@@ -279,53 +279,53 @@ table.sortable tbody tr:hover td {
 */
 
 .apptabs {
-	width:100%;
-	display:inline-block;
+	width: 100%;
+	display: inline-block;
 }
  
 .apptab-links:after {
-	display:block;
-	clear:both;
-	content:'';
+	display: block;
+	clear: both;
+	content: '';
 }
 
 .apptab-links li {
-	margin:5px 5px;
-	float:left;
-	list-style:none;
+	margin: 5px 5px;
+	float: left;
+	list-style: none;
 }
 
 .apptab-links a {
-	padding:6px 6px;
-	display:inline-block;
-	border-radius:3px 3px 3px 3px;
-	background:CornflowerBlue;
-	font-size:16px;
+	padding: 6px 6px;
+	display: inline-block;
+	border-radius: 3px 3px 3px 3px;
+	background: CornflowerBlue;
+	font-size: 16px;
 	min-width: 50px;
 	text-align: center;
-	font-weight:600;
-	color:#000000;
+	font-weight: 600;
+	color: #000000;
 	text-decoration: none;
-	transition:all linear 0.15s;
+	transition: all linear 0.15s;
 }
 
 .apptab-links a:hover {
-	background:#DDC4C4;
-	text-decoration:none;
+	background: #DDC4C4;
+	text-decoration: none;
 }
  
 /*----- Content of Tabs -----*/
 .apptab-content {
-	padding:10px;
-	background:#fdfdfd;
+	padding: 10px;
+	background: #fdfdfd;
 }
  
 .apptab {
-	display:none;
+	display: none;
 }
 
 .apptab.active {
-	display:block;
+	display: block;
 }
 
 

--- a/spyre/public/css/style.css
+++ b/spyre/public/css/style.css
@@ -164,6 +164,14 @@ li.active a, li.active a:hover {
 	float: left;
 }
 
+/*
+* <img>
+*/
+
+.spyreImg {
+	max-width: 100%;
+}
+
 
 /*
 * Button
@@ -197,14 +205,16 @@ li.active a, li.active a:hover {
 	color: #333333;	 
 	background: #f4f4f4;
 	padding: 10px;
-	width:20%;
-	float:left;
+	width: 25%;
+	box-sizing: border-box;
+	float: left;
 }
 
 .content {		
 	padding: 0px 5px 5px 15px;
-	width:75%;
-	float:left;
+	width: 75%;
+	box-sizing: border-box;
+	float: left;
 }​
 
 .bar {
@@ -227,8 +237,8 @@ table.sortable {
 	font-family: Arial, Helvetica, sans-serif;;
 	font-size: 12px;
 	background: #fff;
-	margin: 10px;
-	min-width: 480px;
+	min-width: 380px;
+	max-width: 100%;
 	border-collapse: collapse;
 	text-align: left;
 }

--- a/spyre/public/css/style.css
+++ b/spyre/public/css/style.css
@@ -86,25 +86,16 @@ li.active a, li.active a:hover {
 * Slider
 */
 
-.slider {
-	padding:2px;
-	margin:1px 1px 8px 1px;
-	height:30px;
-	background: #f4f4f4
-}
-
 .slider_value {
-	padding: 3px 1px;
-	margin: 2px 2px;
-	border: 1px 2px;
 	text-align: center;
 	font-size: 12px;
-	float:left;
-	width:14%;
+	float: left;
+	width: 20%;
 }
 
-.slider_slider {
-	width:62%;
+.slider_slider[type="range"] {
+	width: 80%;
+	float: left;
 }
 
 

--- a/spyre/public/css/style.css
+++ b/spyre/public/css/style.css
@@ -217,6 +217,10 @@ li.active a, li.active a:hover {
 	float: left;
 }​
 
+/*
+* Bars
+*/
+
 .bar {
   fill: orange;
 }
@@ -382,3 +386,22 @@ table.sortable tbody tr:hover td {
 .tab.active {
 	display:block;
 }
+
+
+
+
+/*
+* Responsive
+*/
+
+@media (max-width: 600px) {
+	.menu,
+	.content {
+		width: 100%;
+	}
+
+	.content {
+		padding-top: 30px;
+	}
+}
+

--- a/spyre/public/css/style.css
+++ b/spyre/public/css/style.css
@@ -67,9 +67,16 @@ li.active a, li.active a:hover {
 }
 
 /*
-* Slider
+* Container
 */
 
+.container {
+	padding: 20px;
+}
+
+/*
+* Slider
+*/
 
 .slider {
 	padding:2px;
@@ -119,18 +126,17 @@ li.active a, li.active a:hover {
 * Panels
 */
 
-.left-panel {   
+.menu {   
 	font: 14px bold;
 	font-family: Arial, Helvetica, sans-serif;
 	color: #333333;	 
 	background: #f4f4f4;
 	padding: 10px;
 	width:20%;
-	float:left;  
+	float:left;
 }
 
-.right-panel {		
-	background-color:white;
+.content {		
 	padding: 0px 5px 5px 15px;
 	width:75%;
 	float:left;

--- a/spyre/public/css/style.css
+++ b/spyre/public/css/style.css
@@ -83,6 +83,65 @@ li.active a, li.active a:hover {
 }
 
 /*
+* Paddings
+* S: 10px;
+* M: 20px;
+*/
+
+
+.spyrePad--topS {
+	padding-top: 10px;
+	box-sizing: border-box;
+}
+
+.spyrePad--bottomS {
+	padding-bottom: 10px;
+	box-sizing: border-box;
+}
+
+.spyrePad--leftS {
+	padding-left: 10px;
+	box-sizing: border-box;
+}
+
+.spyrePad--rightS {
+	padding-right: 10px;
+	box-sizing: border-box;
+}
+
+.spyrePad--vertS {
+	padding-top: 10px;
+	padding-bottom: 10px;
+	box-sizing: border-box;
+}
+
+.spyrePad--topM {
+	padding-top: 20px;
+	box-sizing: border-box;
+}
+
+.spyrePad--bottomM {
+	padding-bottom: 20px;
+	box-sizing: border-box;
+}
+
+.spyrePad--leftM {
+	padding-left: 20px;
+	box-sizing: border-box;
+}
+
+.spyrePad--rightM {
+	padding-right: 20px;
+	box-sizing: border-box;
+}
+
+.spyrePad--vertM {
+	padding-top: 20px;
+	padding-bottom: 20px;
+	box-sizing: border-box;
+}
+
+/*
 * Slider
 */
 

--- a/spyre/view.html
+++ b/spyre/view.html
@@ -312,7 +312,6 @@
 		<!-- control panel -->
 		<div class="menu">
 			<h1>{{title}}</h1>
-			<hr>
 			<!-- inputs -->
 			{%- for input in inputs %}
 				{% if input['type']=="text" -%}

--- a/spyre/view.html
+++ b/spyre/view.html
@@ -367,7 +367,7 @@
 					{% if input['label'] is defined %}
 						{{input['label']}}:
 					{% endif %}
-					<div class="slider">
+					<div class="slider container">
 						<input type="text" class="slider_value" id="{{input['key']}}_value" value="{{input['value']}}" onchange="inputChange( '{{input['key']}}', '{{input['linked_type']}}', '{{input['linked_key']}}',  '{{input['linked_value']}}','{{input['action_id']}}');">
 						<input type="range" class="slider_slider" id="{{input['key']}}" min="{{input['min']}}" max="{{input['max']}}" step="{{input['step']}}"  value="{{input['value']}}" onchange="inputChange( '{{input['key']}}', 'id', '{{input['linked_type']}}', '{{input['linked_key']}}', '{{input['linked_value']}}', '{{input['action_id']}}');" />
 					</div>

--- a/spyre/view.html
+++ b/spyre/view.html
@@ -289,161 +289,169 @@
 	</head>
 
 	<body>
+		<div class="container">
 
+			{% block banner %}<!-- banner -->{% endblock %}
 
-
-
-	<div class="container">
-
-		{% block banner %}<!-- banner -->{% endblock %}
-		
-		{% if app_bar %}
-			<div class="apptabs">
-				<ul class="apptab-links">
-					{% for route, text in app_bar %}
-						<li><a href="{{route}}">{{text}}</a></li>
-					{% endfor %}
-				</ul>
-			</div>
-		{% endif %}
-
-
-
-		<!-- control panel -->
-		<div class="menu">
-			<h1>{{title}}</h1>
-			<!-- inputs -->
-			{%- for input in inputs %}
-				{% if input['type']=="text" -%}
-					<!-- text input -->
-					<form action="javascript:inputChange( '{{input['key']}}', 'id', '{{input['linked_type']}}', '{{input['linked_key']}}', '{{input['linked_value']}}', '{{input['action_id']}}');">
-					<div class="text_input">
-					{% if input['label'] is defined %}
-						{{input['label']}}:
-					{% endif %}
-					<input type=text value="{{input['value']}}" id="{{input['key']}}" />
-					</div>
-					</form>
-					<br>
-				
-				<!-- dropdown -->
-				{% elif input['type']=="dropdown" -%}
-					<!-- dropdown menu -->
-					<div class="dropdown_input">
-					{% if input['label'] is defined %}
-						{{input['label']}}:
-					{% endif %}
-					<select id="{{input['key']}}"  onchange="inputChange( '{{input['key']}}', 'id', '{{input['linked_type']}}', '{{input['linked_key']}}', '{{input['linked_value']}}', '{{input['action_id']}}');" >
-					{% for option in input['options'] -%}
-						<option value="{{option['value']}}" {% if option['checked']==True %} selected="selected" {% endif %}>{{option['label']}} </option>
-					{%- endfor %}
-					</select><br></div>
-
-				<!-- radiobuttons -->
-				{% elif input['type']=="radiobuttons" -%}
-					<div class="radiobuttons_input" id="{{input['key']}}">
-					{% if input['label'] is defined %}
-						{{input['label']}}:
-					{% endif %}
-					{% for option in input['options'] -%}
-						<br><input type="radio" name="{{input['key']}}" value="{{option['value']}}" {% if option['checked']==True %} checked {% endif %} onclick="inputChange( '{{input['key']}}', 'name', '{{input['linked_type']}}', '{{input['linked_key']}}', '{{input['linked_value']}}', '{{input['action_id']}}');">{{option['label']}}
-					{%- endfor %}
-					</div>
-
-				<!-- checkbox group -->
-				{% elif input['type']=="checkboxgroup" -%}
-					<div class="checkboxgroup_input" id="{{input['key']}}">
-					{% if input['label'] is defined %}
-						{{input['label']}}:
-					{% endif %}
-					{% for option in input['options'] -%}
-						<br><input type="checkbox" name="{{input['key']}}" value="{{option['value']}}" {% if option['checked']==True %} checked {% endif %} onclick="inputChange( '{{input['key']}}', 'name', '{{input['linked_type']}}', '{{input['linked_key']}}', '{{input['linked_value']}}', '{{input['action_id']}}');">{{option['label']}}
-					{%- endfor %}
-					</div>
-				
-				<!-- sliders -->
-				{% elif input['type']=="slider" -%}
-					<div class="slider_input">
-					{% if input['label'] is defined %}
-						{{input['label']}}:
-					{% endif %}
-					<div class="slider container">
-						<input type="text" class="slider_value" id="{{input['key']}}_value" value="{{input['value']}}" onchange="inputChange( '{{input['key']}}', '{{input['linked_type']}}', '{{input['linked_key']}}',  '{{input['linked_value']}}','{{input['action_id']}}');">
-						<input type="range" class="slider_slider" id="{{input['key']}}" min="{{input['min']}}" max="{{input['max']}}" step="{{input['step']}}"  value="{{input['value']}}" onchange="inputChange( '{{input['key']}}', 'id', '{{input['linked_type']}}', '{{input['linked_key']}}', '{{input['linked_value']}}', '{{input['action_id']}}');" />
-					</div>
-					</div>
-				{%- endif %}
-			{%- endfor %}
-
-			<!-- buttons -->
-			{%- for control in controls %}
-				{% if control['type']=="button" -%}
-					<div class="button" id="{{control['id']}}" >{{control['label']}}</div><br>
-				{%- endif %}
-			{%- endfor %}
-			{% if False -%}
-				<div class="button" id="share_url" >Generate Sharable URL</div><br>
-			{%- endif %}
-		</div>
-
-		<!-- output -->
-		<div class="content">
-			<img scr="">
-			{% if tabs is defined -%}
-				<div class="tabs">
-					<ul class="tab-links">
-						{% for tab in tabs -%}
-							{% if loop.index == 1 -%}
-								<li class="active"><a href="#{{tab}}">{{tab}}</a></li>
-							{% else -%}
-								<li><a href="#{{tab}}">{{tab}}</a></li>
-							{%- endif %}
-						{%- endfor %}
+			{% if app_bar %}
+				<div class="apptabs">
+					<ul class="apptab-links">
+						{% for route, text in app_bar %}
+							<li>
+								<a href="{{route}}">{{text}}</a>
+							</li>
+						{% endfor %}
 					</ul>
+				</div>
+			{% endif %}
 
-					<div class="tab-content">
-						{% for tab in tabs -%}
-							{%- if loop.index == 1 %}
-								<div id="{{tab}}" class="tab active">
-							{%- else %}
-								<div id="{{tab}}" class="tab">
-							{%- endif %}
-							{%- for output in outputs %}
-								{%- if output['tab'] == tab %}
-									{%- if output['type'] != "d3" %}
-										<!-- plots, custom html, or table -->
-										<div id="{{output['id']}}"></div>
-									{%- endif %}
 
-									{%- if output['type'] == "d3" %}
-										<!-- d3 figs go here -->
-										<div id="chart"></div>
-									{%- endif %}
-								{%- endif %}
+
+			<!-- control panel -->
+			<div class="menu">
+				<h1>{{title}}</h1>
+				<!-- inputs -->
+				{%- for input in inputs %}
+					{% if input['input_type']=="text" -%}
+						<!-- text input -->
+						<form action="javascript:inputChange( '{{input['variable_name']}}', 'id', '{{input['linked_variable_type']}}', '{{input['linked_variable_name']}}', '{{input['linked_value']}}', '{{input['action_id']}}');">
+							<div class="text_input">
+								{% if input['label'] is defined %}
+									{{input['label']}}:
+								{% endif %}
+								<input type=text value="{{input['value']}}" id="{{input['variable_name']}}" />
+							</div>
+						</form>
+						<br>
+
+					<!-- dropdown -->
+					{% elif input['input_type']=="dropdown" -%}
+						<!-- dropdown menu -->
+						<div class="dropdown_input">
+							{% if input['label'] is defined %}
+								{{input['label']}}:
+							{% endif %}
+							<select id="{{input['variable_name']}}"  onchange="inputChange( '{{input['variable_name']}}', 'id', '{{input['linked_variable_type']}}', '{{input['linked_variable_name']}}', '{{input['linked_value']}}', '{{input['action_id']}}');" >
+								{% for option in input['options'] -%}
+									<option value="{{option['value']}}" {% if option['checked']==True %} selected="selected" {% endif %}>
+										{{option['label']}}
+									</option>
+								{%- endfor %}
+							</select>
+							<br>
+						</div>
+
+					<!-- radiobuttons -->
+					{% elif input['input_type']=="radiobuttons" -%}
+						<div class="radiobuttons_input" id="{{input['variable_name']}}">
+							{% if input['label'] is defined %}
+								{{input['label']}}:
+							{% endif %}
+							{% for option in input['options'] -%}
+								<br>
+								<input type="radio" name="{{input['variable_name']}}" value="{{option['value']}}" {% if option['checked']==True %} checked {% endif %} onclick="inputChange( '{{input['variable_name']}}', 'name', '{{input['linked_variable_type']}}', '{{input['linked_variable_name']}}', '{{input['linked_value']}}', '{{input['action_id']}}');">
+								{{option['label']}}
 							{%- endfor %}
-								</div>
-						{%- endfor %}
+						</div>
 
-					</div>
-			</div>
-			{% else -%}	
+					<!-- checkbox group -->
+					{% elif input['input_type']=="checkboxgroup" -%}
+						<div class="checkboxgroup_input" id="{{input['variable_name']}}">
+							{% if input['label'] is defined %}
+								{{input['label']}}:
+							{% endif %}
+							{% for option in input['options'] -%}
+								<br>
+								<input type="checkbox" name="{{input['variable_name']}}" value="{{option['value']}}" {% if option['checked']==True %} checked {% endif %} onclick="inputChange( '{{input['variable_name']}}', 'name', '{{input['linked_variable_type']}}', '{{input['linked_variable_name']}}', '{{input['linked_value']}}', '{{input['action_id']}}');">
+								{{option['label']}}
+							{%- endfor %}
+						</div>
 
-				{%- for output in outputs %}
-					<!-- plots, custom html, tables, anything not d3 -->
-					{% if output['type'] != "d3" -%}
-						<div id="{{output['id']}}"></div>
-						<div id="{{output['id']}}_spinner"></div>
-					{%- endif %}
-
-					{% if output['type'] == "d3" -%}
-						<!-- d3 figs go here -->
-						<div id="chart"></div>
+					<!-- sliders -->
+					{% elif input['input_type']=="slider" -%}
+						<div class="slider_input">
+							{% if input['label'] is defined %}
+								{{input['label']}}:
+							{% endif %}
+							<div class="slider container">
+								<input type="text" class="slider_value" id="{{input['variable_name']}}_value" value="{{input['value']}}" onchange="inputChange( '{{input['variable_name']}}', '{{input['linked_variable_type']}}', '{{input['linked_variable_name']}}',  '{{input['linked_value']}}','{{input['action_id']}}');">
+								<input type="range" class="slider_slider" id="{{input['variable_name']}}" min="{{input['min']}}" max="{{input['max']}}" step="{{input['step']}}"  value="{{input['value']}}" onchange="inputChange( '{{input['variable_name']}}', 'id', '{{input['linked_variable_type']}}', '{{input['linked_variable_name']}}', '{{input['linked_value']}}', '{{input['action_id']}}');" />
+							</div>
+						</div>
 					{%- endif %}
 				{%- endfor %}
 
-			{%- endif %}
-		</div>
+				<!-- buttons -->
+				{%- for control in controls %}
+					{% if control['control_type']=="button" -%}
+						<div class="button" id="{{control['control_id']}}" >
+							{{control['label']}}
+						</div>
+						<br>
+					{%- endif %}
+				{%- endfor %}
+				{% if False -%}
+					<div class="button" id="share_url" >
+						Generate Sharable URL
+					</div>
+					<br>
+				{%- endif %}
+			</div>
 
-	</div>
+			<!-- output -->
+			<div class="content">
+				<img scr="">
+				{% if tabs is defined -%}
+					<div class="tabs">
+						<ul class="tab-links">
+							{% for tab in tabs -%}
+								{% if loop.index == 1 -%}
+									<li class="active">
+										<a href="#{{tab}}">{{tab}}</a>
+									</li>
+								{% else -%}
+									<li>
+										<a href="#{{tab}}">{{tab}}</a>
+									</li>
+								{%- endif %}
+							{%- endfor %}
+						</ul>
+
+						<div class="tab-content">
+							{% for tab in tabs -%}
+								<div id="{{tab}}" class="tab {%- if loop.index == 1 %} active {%- endif %}">
+									{%- for output in outputs %}
+										{%- if output['tab'] == tab %}
+											{%- if output['output_type'] != "d3" %}
+												<!-- plots, custom html, or table -->
+												<div id="{{output['output_id']}}"></div>
+											{%- endif %}
+
+											{%- if output['output_type'] == "d3" %}
+												<!-- d3 figs go here -->
+												<div id="chart"></div>
+											{%- endif %}
+										{%- endif %}
+									{%- endfor %}
+								</div>
+							{%- endfor %}
+						</div>
+					</div>
+				{% else -%}	
+					{%- for output in outputs %}
+						<!-- plots, custom html, tables, anything not d3 -->
+						{% if output['output_type'] != "d3" -%}
+							<div id="{{output['output_id']}}"></div>
+							<div id="{{output['output_id']}}_spinner"></div>
+						{%- endif %}
+
+						{% if output['output_type'] == "d3" -%}
+							<!-- d3 figs go here -->
+							<div id="chart"></div>
+						{%- endif %}
+					{%- endfor %}
+				{%- endif %}
+			</div>
+		</div>
 	</body>
 </html>

--- a/spyre/view.html
+++ b/spyre/view.html
@@ -133,7 +133,7 @@
 						var params = updateSharedParameters();
 						params = params+"output_id={{output['id']}}&";
 						
-						var plot = $("<img />").addClass('spyreImg').attr('src', "plot?"+params).load(function(){
+						var plot = $("<img />").attr('src', "plot?"+params).load(function(){
 							$("#{{output['id']}}").html("");
 							$("#{{output['id']}}").append(plot)
 						});

--- a/spyre/view.html
+++ b/spyre/view.html
@@ -134,8 +134,8 @@
 						params = params+"output_id={{output['id']}}&";
 						
 						var plot = $("<img />").addClass('spyreImg').attr('src', "plot?"+params).load(function(){
-							$("#{{output['output_id']}}").html("");
-							$("#{{output['output_id']}}").append(plot)
+							$("#{{output['id']}}").html("");
+							$("#{{output['id']}}").append(plot)
 						});
 					}
 				{%- endif %}
@@ -312,27 +312,27 @@
 				<h1>{{title}}</h1>
 				<!-- inputs -->
 				{%- for input in inputs %}
-					{% if input['input_type']=="text" -%}
+					{% if input['type']=="text" -%}
 						<div class="spyrePad--vertS">
 							<!-- text input -->
-							<form action="javascript:inputChange( '{{input['variable_name']}}', 'id', '{{input['linked_variable_type']}}', '{{input['linked_variable_name']}}', '{{input['linked_value']}}', '{{input['action_id']}}');">
+							<form action="javascript:inputChange( '{{input['key']}}', 'id', '{{input['linked_type']}}', '{{input['linked_key']}}', '{{input['linked_value']}}', '{{input['action_id']}}');">
 								<div class="text_input">
 									{% if input['label'] is defined %}
 										{{input['label']}}:
 									{% endif %}
-									<input type="text" value="{{input['value']}}" id="{{input['variable_name']}}" />
+									<input type="text" value="{{input['value']}}" id="{{input['key']}}" />
 								</div>
 							</form>
 						</div>
 
 					<!-- dropdown -->
-					{% elif input['input_type']=="dropdown" -%}
+					{% elif input['type']=="dropdown" -%}
 						<!-- dropdown menu -->
 						<div class="spyrePad--vertS">
 							{% if input['label'] is defined %}
 								{{input['label']}}:
 							{% endif %}
-							<select id="{{input['variable_name']}}"  onchange="inputChange( '{{input['variable_name']}}', 'id', '{{input['linked_variable_type']}}', '{{input['linked_variable_name']}}', '{{input['linked_value']}}', '{{input['action_id']}}');" >
+							<select id="{{input['key']}}"  onchange="inputChange( '{{input['key']}}', 'id', '{{input['linked_type']}}', '{{input['linked_key']}}', '{{input['linked_value']}}', '{{input['action_id']}}');" >
 								{% for option in input['options'] -%}
 									<option value="{{option['value']}}" {% if option['checked']==True %} selected="selected" {% endif %}>
 										{{option['label']}}
@@ -342,48 +342,48 @@
 						</div>
 
 					<!-- radiobuttons -->
-					{% elif input['input_type']=="radiobuttons" -%}
+					{% elif input['type']=="radiobuttons" -%}
 						<div
 							class="spyrePad--vertS"
-							id="{{input['variable_name']}}"
+							id="{{input['key']}}"
 						>
 							{% if input['label'] is defined %}
 								{{input['label']}}:
 							{% endif %}
 							{% for option in input['options'] -%}
 								<div>
-									<input type="radio" name="{{input['variable_name']}}" value="{{option['value']}}" {% if option['checked']==True %} checked {% endif %} onclick="inputChange( '{{input['variable_name']}}', 'name', '{{input['linked_variable_type']}}', '{{input['linked_variable_name']}}', '{{input['linked_value']}}', '{{input['action_id']}}');">
+									<input type="radio" name="{{input['key']}}" value="{{option['value']}}" {% if option['checked']==True %} checked {% endif %} onclick="inputChange( '{{input['key']}}', 'name', '{{input['linked_type']}}', '{{input['linked_key']}}', '{{input['linked_value']}}', '{{input['action_id']}}');">
 									{{option['label']}}
 								</div>
 							{%- endfor %}
 						</div>
 
 					<!-- checkbox group -->
-					{% elif input['input_type']=="checkboxgroup" -%}
+					{% elif input['type']=="checkboxgroup" -%}
 						<div
 							class="spyrePad--vertS"
-							id="{{input['variable_name']}}"
+							id="{{input['key']}}"
 						>
 							{% if input['label'] is defined %}
 								{{input['label']}}:
 							{% endif %}
 							{% for option in input['options'] -%}
 								<div>
-									<input type="checkbox" name="{{input['variable_name']}}" value="{{option['value']}}" {% if option['checked']==True %} checked {% endif %} onclick="inputChange( '{{input['variable_name']}}', 'name', '{{input['linked_variable_type']}}', '{{input['linked_variable_name']}}', '{{input['linked_value']}}', '{{input['action_id']}}');">
+									<input type="checkbox" name="{{input['key']}}" value="{{option['value']}}" {% if option['checked']==True %} checked {% endif %} onclick="inputChange( '{{input['key']}}', 'name', '{{input['linked_type']}}', '{{input['linked_key']}}', '{{input['linked_value']}}', '{{input['action_id']}}');">
 									{{option['label']}}
 								</div>
 							{%- endfor %}
 						</div>
 
 					<!-- sliders -->
-					{% elif input['input_type']=="slider" -%}
+					{% elif input['type']=="slider" -%}
 						<div class="spyrePad--vertS">
 							{% if input['label'] is defined %}
 								{{input['label']}}:
 							{% endif %}
 							<div class="slider container">
-								<input type="text" class="slider_value" id="{{input['variable_name']}}_value" value="{{input['value']}}" onchange="inputChange( '{{input['variable_name']}}', '{{input['linked_variable_type']}}', '{{input['linked_variable_name']}}',  '{{input['linked_value']}}','{{input['action_id']}}');">
-								<input type="range" class="slider_slider" id="{{input['variable_name']}}" min="{{input['min']}}" max="{{input['max']}}" step="{{input['step']}}"  value="{{input['value']}}" onchange="inputChange( '{{input['variable_name']}}', 'id', '{{input['linked_variable_type']}}', '{{input['linked_variable_name']}}', '{{input['linked_value']}}', '{{input['action_id']}}');" />
+								<input type="text" class="slider_value" id="{{input['key']}}_value" value="{{input['value']}}" onchange="inputChange( '{{input['key']}}', '{{input['linked_type']}}', '{{input['linked_key']}}',  '{{input['linked_value']}}','{{input['action_id']}}');">
+								<input type="range" class="slider_slider" id="{{input['key']}}" min="{{input['min']}}" max="{{input['max']}}" step="{{input['step']}}"  value="{{input['value']}}" onchange="inputChange( '{{input['key']}}', 'id', '{{input['linked_type']}}', '{{input['linked_key']}}', '{{input['linked_value']}}', '{{input['action_id']}}');" />
 							</div>
 						</div>
 					{%- endif %}
@@ -391,9 +391,9 @@
 
 				<!-- buttons -->
 				{%- for control in controls %}
-					{% if control['control_type']=="button" -%}
+					{% if control['type']=="button" -%}
 						<div class="spyrePad--vertXS">
-							<div class="button" id="{{control['control_id']}}" >
+							<div class="button" id="{{control['id']}}" >
 								{{control['label']}}
 							</div>
 						</div>
@@ -432,14 +432,14 @@
 								<div id="{{tab}}" class="tab {%- if loop.index == 1 %} active {%- endif %}">
 									{%- for output in outputs %}
 										{%- if output['tab'] == tab %}
-											{%- if output['output_type'] != "d3" %}
+											{%- if output['type'] != "d3" %}
 												<!-- plots, custom html, or table -->
 												<div class="spyrePad--bottomM">
-													<div id="{{output['output_id']}}"></div>
+													<div id="{{output['id']}}"></div>
 												</div>
 											{%- endif %}
 
-											{%- if output['output_type'] == "d3" %}
+											{%- if output['type'] == "d3" %}
 												<!-- d3 figs go here -->
 												<div class="spyrePad--bottomM">
 													<div id="chart"></div>
@@ -454,14 +454,14 @@
 				{% else -%}	
 					{%- for output in outputs %}
 						<!-- plots, custom html, tables, anything not d3 -->
-						{% if output['output_type'] != "d3" -%}
+						{% if output['type'] != "d3" -%}
 							<div class="spyrePad--bottomM">
-								<div id="{{output['output_id']}}"></div>
-								<div id="{{output['output_id']}}_spinner"></div>
+								<div id="{{output['id']}}"></div>
+								<div id="{{output['id']}}_spinner"></div>
 							</div>
 						{%- endif %}
 
-						{% if output['output_type'] == "d3" -%}
+						{% if output['type'] == "d3" -%}
 							<!-- d3 figs go here -->
 							<div id="chart"></div>
 						{%- endif %}

--- a/spyre/view.html
+++ b/spyre/view.html
@@ -334,9 +334,7 @@
 							{% endif %}
 							<select id="{{input['key']}}"  onchange="inputChange( '{{input['key']}}', 'id', '{{input['linked_type']}}', '{{input['linked_key']}}', '{{input['linked_value']}}', '{{input['action_id']}}');" >
 								{% for option in input['options'] -%}
-									<option value="{{option['value']}}" {% if option['checked']==True %} selected="selected" {% endif %}>
-										{{option['label']}}
-									</option>
+									<option value="{{option['value']}}" {% if option['checked']==True %} selected="selected" {% endif %}>{{option['label']}}</option>
 								{%- endfor %}
 							</select>
 						</div>

--- a/spyre/view.html
+++ b/spyre/view.html
@@ -434,12 +434,16 @@
 										{%- if output['tab'] == tab %}
 											{%- if output['output_type'] != "d3" %}
 												<!-- plots, custom html, or table -->
-												<div id="{{output['output_id']}}"></div>
+												<div class="spyrePad--bottomM">
+													<div id="{{output['output_id']}}"></div>
+												</div>
 											{%- endif %}
 
 											{%- if output['output_type'] == "d3" %}
 												<!-- d3 figs go here -->
-												<div id="chart"></div>
+												<div class="spyrePad--bottomM">
+													<div id="chart"></div>
+												</div>
 											{%- endif %}
 										{%- endif %}
 									{%- endfor %}
@@ -451,8 +455,10 @@
 					{%- for output in outputs %}
 						<!-- plots, custom html, tables, anything not d3 -->
 						{% if output['output_type'] != "d3" -%}
-							<div id="{{output['output_id']}}"></div>
-							<div id="{{output['output_id']}}_spinner"></div>
+							<div class="spyrePad--bottomM">
+								<div id="{{output['output_id']}}"></div>
+								<div id="{{output['output_id']}}_spinner"></div>
+							</div>
 						{%- endif %}
 
 						{% if output['output_type'] == "d3" -%}

--- a/spyre/view.html
+++ b/spyre/view.html
@@ -313,21 +313,22 @@
 				<!-- inputs -->
 				{%- for input in inputs %}
 					{% if input['input_type']=="text" -%}
-						<!-- text input -->
-						<form action="javascript:inputChange( '{{input['variable_name']}}', 'id', '{{input['linked_variable_type']}}', '{{input['linked_variable_name']}}', '{{input['linked_value']}}', '{{input['action_id']}}');">
-							<div class="text_input">
-								{% if input['label'] is defined %}
-									{{input['label']}}:
-								{% endif %}
-								<input type=text value="{{input['value']}}" id="{{input['variable_name']}}" />
-							</div>
-						</form>
-						<br>
+						<div class="spyrePad--vertS">
+							<!-- text input -->
+							<form action="javascript:inputChange( '{{input['variable_name']}}', 'id', '{{input['linked_variable_type']}}', '{{input['linked_variable_name']}}', '{{input['linked_value']}}', '{{input['action_id']}}');">
+								<div class="text_input">
+									{% if input['label'] is defined %}
+										{{input['label']}}:
+									{% endif %}
+									<input type="text" value="{{input['value']}}" id="{{input['variable_name']}}" />
+								</div>
+							</form>
+						</div>
 
 					<!-- dropdown -->
 					{% elif input['input_type']=="dropdown" -%}
 						<!-- dropdown menu -->
-						<div class="dropdown_input">
+						<div class="spyrePad--vertS">
 							{% if input['label'] is defined %}
 								{{input['label']}}:
 							{% endif %}
@@ -338,38 +339,45 @@
 									</option>
 								{%- endfor %}
 							</select>
-							<br>
 						</div>
 
 					<!-- radiobuttons -->
 					{% elif input['input_type']=="radiobuttons" -%}
-						<div class="radiobuttons_input" id="{{input['variable_name']}}">
+						<div
+							class="spyrePad--vertS"
+							id="{{input['variable_name']}}"
+						>
 							{% if input['label'] is defined %}
 								{{input['label']}}:
 							{% endif %}
 							{% for option in input['options'] -%}
-								<br>
-								<input type="radio" name="{{input['variable_name']}}" value="{{option['value']}}" {% if option['checked']==True %} checked {% endif %} onclick="inputChange( '{{input['variable_name']}}', 'name', '{{input['linked_variable_type']}}', '{{input['linked_variable_name']}}', '{{input['linked_value']}}', '{{input['action_id']}}');">
-								{{option['label']}}
+								<div>
+									<input type="radio" name="{{input['variable_name']}}" value="{{option['value']}}" {% if option['checked']==True %} checked {% endif %} onclick="inputChange( '{{input['variable_name']}}', 'name', '{{input['linked_variable_type']}}', '{{input['linked_variable_name']}}', '{{input['linked_value']}}', '{{input['action_id']}}');">
+									{{option['label']}}
+								</div>
 							{%- endfor %}
 						</div>
 
 					<!-- checkbox group -->
 					{% elif input['input_type']=="checkboxgroup" -%}
-						<div class="checkboxgroup_input" id="{{input['variable_name']}}">
+						<div
+							class="spyrePad--vertS"
+							id="{{input['variable_name']}}"
+						>
 							{% if input['label'] is defined %}
 								{{input['label']}}:
 							{% endif %}
 							{% for option in input['options'] -%}
-								<br>
-								<input type="checkbox" name="{{input['variable_name']}}" value="{{option['value']}}" {% if option['checked']==True %} checked {% endif %} onclick="inputChange( '{{input['variable_name']}}', 'name', '{{input['linked_variable_type']}}', '{{input['linked_variable_name']}}', '{{input['linked_value']}}', '{{input['action_id']}}');">
-								{{option['label']}}
+								<div>
+									<input type="checkbox" name="{{input['variable_name']}}" value="{{option['value']}}" {% if option['checked']==True %} checked {% endif %} onclick="inputChange( '{{input['variable_name']}}', 'name', '{{input['linked_variable_type']}}', '{{input['linked_variable_name']}}', '{{input['linked_value']}}', '{{input['action_id']}}');">
+									{{option['label']}}
+								</div>
 							{%- endfor %}
 						</div>
 
 					<!-- sliders -->
 					{% elif input['input_type']=="slider" -%}
-						<div class="slider_input">
+						<div class="spyrePad--vertS">
 							{% if input['label'] is defined %}
 								{{input['label']}}:
 							{% endif %}
@@ -384,17 +392,19 @@
 				<!-- buttons -->
 				{%- for control in controls %}
 					{% if control['control_type']=="button" -%}
-						<div class="button" id="{{control['control_id']}}" >
-							{{control['label']}}
+						<div class="spyrePad--vertXS">
+							<div class="button" id="{{control['control_id']}}" >
+								{{control['label']}}
+							</div>
 						</div>
-						<br>
 					{%- endif %}
 				{%- endfor %}
 				{% if False -%}
-					<div class="button" id="share_url" >
-						Generate Sharable URL
+					<div class="spyrePad--vertXS">
+						<div class="button" id="share_url" >
+							Generate Sharable URL
+						</div>
 					</div>
-					<br>
 				{%- endif %}
 			</div>
 

--- a/spyre/view.html
+++ b/spyre/view.html
@@ -293,7 +293,7 @@
 
 
 
-	<div class="outer">
+	<div class="container">
 
 		{% block banner %}<!-- banner -->{% endblock %}
 		
@@ -310,7 +310,7 @@
 
 
 		<!-- control panel -->
-		<div class="left-panel">
+		<div class="menu">
 			<h1>{{title}}</h1>
 			<hr>
 			<!-- inputs -->
@@ -388,7 +388,7 @@
 		</div>
 
 		<!-- output -->
-		<div class="right-panel">
+		<div class="content">
 			<img scr="">
 			{% if tabs is defined -%}
 				<div class="tabs">

--- a/spyre/view.html
+++ b/spyre/view.html
@@ -10,7 +10,7 @@
 		<style>{{custom_css}}</style>
 		{{custom_head}}
 		<title>{{title}}</title>
-
+		<meta name="viewport" content="width=device-width, initial-scale=1">
 		<!-- load javascript -->
 		<script type='text/javascript'>{{js}}</script>
 

--- a/spyre/view.html
+++ b/spyre/view.html
@@ -133,9 +133,9 @@
 						var params = updateSharedParameters();
 						params = params+"output_id={{output['id']}}&";
 						
-						var plot = $("<img />").attr('src', "plot?"+params).load(function(){
-							$("#{{output['id']}}").html("");
-							$("#{{output['id']}}").append(plot)
+						var plot = $("<img />").addClass('spyreImg').attr('src', "plot?"+params).load(function(){
+							$("#{{output['output_id']}}").html("");
+							$("#{{output['output_id']}}").append(plot)
 						});
 					}
 				{%- endif %}


### PR DESCRIPTION
Cleaning Spyre's CSS & HTML in order to have a better foundation for upcoming design and UX updates. This PR includes a first working responsive design, while being very simple.

I went with a lot of small commits so anyone can follow the process. It's not perfect yet, but it makes the front-end easier to understand and improve.

Design is not ~really affected by this PR. Always did my best to keep it the way it was and only make it cleaner / more reliable and with more consistent spacing.

## What changed

### CSS

- cleaned indentation and structure (everything under a category)
- Clean app title
- made sure the container was handling correctly the menu and the content elements which are floats
- removed all `!important` tags
- created `spyrePad` (allowing to add all kind of paddings from 5 to 20px)
- use the full width of the page, container being 100% and everything inside filling it totally (thanks to `box-sizing: border-box`)
- first responsive feature by making the menu and content take the full width of the page when screen size is < 600px (didn't get to test on mobile but it should improve the experience)


### HTML

- Clean indentation (better reading)
- Remove classes with no styling (like `dropdown_input` or `radiobutton_input`)
- add meta tag for responsive design
- add proper container
- use SpyrePad for design consistency and to prevent the use or `<br>`


Responsive example:

Size | Capture
--- | ---
Full | ![test app 1--full2](https://cloud.githubusercontent.com/assets/3630005/9296274/d62e2a36-443d-11e5-9e5e-cbc2ab6c8a6b.png)
Medium | ![test app 1--med2](https://cloud.githubusercontent.com/assets/3630005/9296273/d3b12be6-443d-11e5-8fef-344630e6f7ff.png)
Small (< 600px wide) | ![test app 1--small](https://cloud.githubusercontent.com/assets/3630005/9296256/3b9bcf64-443d-11e5-8b39-4b9cfcb1f7c7.png)

## What's next?

- Improving the elements design (buttons, tabs, inputs, slider etc)
- Improving JS
- Improving UX + responsiveness


Please note that all these changes have been made while working with `example_show_all_the_inputs.py` assuming it contains most of what we can find in Spyre. I'm not sure of which other examples should also be tested.

PR sponsored by The Smile Sessions by the Beach Boys & being 36928 feet from the ocean ✌️