### PR TITLE
Add an optional prefix parameter to server.App.launch.

### DIFF
--- a/spyre/server.py
+++ b/spyre/server.py
@@ -402,11 +402,12 @@ class App(object):
 		"""
 		return ""
 
-	def launch(self,host="local",port=8080):
+	def launch(self,host="local",port=8080,prefix='/'):
 		webapp = self.getRoot()
 		if host!="local":
 			cherrypy.server.socket_host = '0.0.0.0'
 		cherrypy.server.socket_port = port
+		cherrypy.tree.mount(webapp,prefix)
 		cherrypy.quickstart(webapp)
 
 

--- a/spyre/server.py
+++ b/spyre/server.py
@@ -60,13 +60,15 @@ class Root(object):
 		getCustomHeadFunction=None, 
 		getHTMLFunction=None,  
 		getDownloadFunction=None, 
-		noOutputFunction=None):
+		noOutputFunction=None,
+		prefix='/'):
 		# populate template dictionary for creating input,controler, and output HTML and javascript
 		if templateVars is not None:
 			self.templateVars = templateVars
 		else:
 			self.templateVars = {}
 			self.templateVars['title'] = title
+			self.templateVars['prefix'] = prefix
 			# necessary to ensure that spyre apps prior to version 0.2.0 still work
 			for input in inputs:
 				if 'input_type' in input:
@@ -272,6 +274,7 @@ class App(object):
 	tabs = None
 	spinnerFile = None
 	templateVars = None
+	prefix = '/'
 
 	def getJsonData(self, params):
 		"""turns the DataFrame returned by getData into a dictionary
@@ -403,6 +406,7 @@ class App(object):
 		return ""
 
 	def launch(self,host="local",port=8080,prefix='/'):
+		self.prefix = prefix
 		webapp = self.getRoot()
 		if host!="local":
 			cherrypy.server.socket_host = '0.0.0.0'
@@ -440,7 +444,8 @@ class App(object):
 			getCustomHeadFunction=self.getCustomHead, 
 			getHTMLFunction=self.getHTML, 
 			getDownloadFunction=self.getDownload, 
-			noOutputFunction=self.noOutput)
+			noOutputFunction=self.noOutput,
+			prefix=self.prefix)
 		return webapp
 class Site(object):
 	"""Creates a 'tree' of cherrypy 'Root' objects that allow for the

--- a/spyre/view.html
+++ b/spyre/view.html
@@ -127,7 +127,7 @@
 				{%- if output['type']=='plot' %}
 					// load plot function
 					function {{output['id']}}(){
-						var spinning_wheel = $("<img />").attr('src', "/spinning_wheel");
+						var spinning_wheel = $("<img />").attr('src', "{{prefix}}/spinning_wheel");
 						$("#{{output['id']}}").html(spinning_wheel);
 
 						var params = updateSharedParameters();
@@ -153,7 +153,7 @@
 				{%- if output['type']=='html' %}
 					// custom html function
 					function {{output['id']}}(){
-						var spinning_wheel = $("<img />").attr('src', "/spinning_wheel");
+						var spinning_wheel = $("<img />").attr('src', "{{prefix}}/spinning_wheel");
 						$("#{{output['id']}}").html(spinning_wheel);
 
 						var params = updateSharedParameters();
@@ -170,7 +170,7 @@
 				{%- if output['type']=='table' %}
 					// table output function
 					function {{output['id']}}(){
-						var spinning_wheel = $("<img />").attr('src', "/spinning_wheel");
+						var spinning_wheel = $("<img />").attr('src', "{{prefix}}/spinning_wheel");
 						$("#{{output['id']}}").html(spinning_wheel);
 						updateSharedParameters()
 						var params = updateSharedParameters();


### PR DESCRIPTION
    When running Spyre through a proxy server such as
    NGinx the app may not be located at the server
    root folder. An arbitrary URL prefix can be
    specified by passing the Root instance to
    cherrypy.tree.mount along with the prefix.