### PR TITLE
added authentication to spyre 

### DIFF
--- a/spyre/server.py
+++ b/spyre/server.py
@@ -14,6 +14,9 @@ import cherrypy
 from cherrypy.lib.static import serve_file
 from cherrypy.lib.static import serve_fileobj
 
+#password auth
+from cherrypy.lib import auth_digest
+
 try:
     import StringIO as io  # python2
 except Exception:
@@ -478,14 +481,14 @@ class App(object):
         """
         return ""
 
-    def launch(self, host="local", port=8080, prefix='/'):
+    def launch(self, host="local", port=8080, prefix='/', config=None):
         self.prefix = prefix
         webapp = self.getRoot()
         if host != "local":
             cherrypy.server.socket_host = '0.0.0.0'
         cherrypy.server.socket_port = port
         cherrypy.tree.mount(webapp, prefix)
-        cherrypy.quickstart(webapp)
+        cherrypy.quickstart(webapp, config=config)
 
     def launch_in_notebook(self, port=9095, width=900, height=600):
         """launch the app within an iframe in ipython notebook"""


### PR DESCRIPTION
The following is a working example

```
from spyre import server

class SimpleApp(server.App):
	title = "Simple App"
	inputs = [{
		"type": "text",
		"key": "words",
		"label": "write words here",
		"value": "hello world",
		"action_id": "simple_html_output"
	}]

	outputs = [{
		"type": "html",
		"id": "simple_html_output"
	}]

	def getHTML(self, params):
		words = params["words"]
		return "Here's what you wrote in the textbox: <b>%s</b>" % words

USERS={"alice":"secret"}

from cherrypy.lib import auth_digest #must import this to compute ha1 digest
digest_auth = {'/': {'tools.auth_digest.on': True,
               'tools.auth_digest.realm': 'wonderland',
               'tools.auth_digest.get_ha1': auth_digest.get_ha1_dict_plain(USERS),
               'tools.auth_digest.key': 'a565c27146791cfb',
}}

app = SimpleApp()
app.launch(config=digest_auth)
```