### PR TITLE
Make spyre able to handle dashboards that load additional code using require.js

### DIFF
--- a/spyre/server.py
+++ b/spyre/server.py
@@ -478,14 +478,14 @@ class App(object):
         """
         return ""
 
-    def launch(self, host="local", port=8080, prefix='/'):
+    def launch(self, host="local", port=8080, prefix='/', config=None):
         self.prefix = prefix
         webapp = self.getRoot()
         if host != "local":
             cherrypy.server.socket_host = '0.0.0.0'
         cherrypy.server.socket_port = port
         cherrypy.tree.mount(webapp, prefix)
-        cherrypy.quickstart(webapp)
+        cherrypy.quickstart(webapp, config=config)
 
     def launch_in_notebook(self, port=9095, width=900, height=600):
         """launch the app within an iframe in ipython notebook"""

--- a/spyre/view.html
+++ b/spyre/view.html
@@ -8,7 +8,6 @@
 		<style>{{d3css}}</style>
 		<style>{{css}}</style>
 		<style>{{custom_css}}</style>
-		{{custom_head}}
 		<title>{{title}}</title>
 		<meta name="viewport" content="width=device-width, initial-scale=1">
 		<!-- load javascript -->
@@ -16,7 +15,6 @@
 
 		<script type='text/javascript'>
 			{{d3js}}
-			{{custom_js}}
 
 			function updateSharedParameters(){
 				var shared_params = "";
@@ -313,6 +311,10 @@
 					{%- endif %}
 				{%- endfor %}
 			});
+		</script>
+		{{custom_head}}
+		<script type='text/javascript'>
+			{{custom_js}}
 		</script>
 	</head>
 


### PR DESCRIPTION
This involves adding the ability to pass a config to CherryPy on startup, and moving the custom HTML and JS template variables to the end of the \<head\> element.  More about this here: https://github.com/adamhajari/spyre/issues/83
